### PR TITLE
Get rid of libxml-sax library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ cache:
   - $HOME/.ghc
   - $HOME/.cabal
   - $HOME/.stack
+  - $TRAVIS_BUILD_DIR/.stack-work
 
 # The different configurations we want to test. We have BUILD=cabal which uses
 # cabal-install, and BUILD=stack which uses Stack. More documentation on each
@@ -59,9 +60,9 @@ matrix:
   - env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 8.2.2"
     addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=8.4.1 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 8.4.1"
-    addons: {apt: {packages: [cabal-install-2.0,ghc-8.4.1,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.4.3 CABALVER=2.2 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.4.3"
+    addons: {apt: {packages: [cabal-install-2.2,ghc-8.4.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
   # Build with the newest GHC and cabal-install. This is an accepted failure,
   # see below.
@@ -99,6 +100,10 @@ matrix:
     compiler: ": #stack 8.2.2"
     addons: {apt: {packages: [libgmp-dev]}}
 
+  - env: BUILD=stack ARGS="--resolver lts-12"
+    compiler: ": #stack 8.4.3"
+    addons: {apt: {packages: [libgmp-dev]}}
+
   # Nightly builds are allowed to fail
   - env: BUILD=stack ARGS="--resolver nightly"
     compiler: ": #stack nightly"
@@ -124,9 +129,9 @@ before_install:
 - |
   if [ `uname` = "Darwin" ]
   then
-    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+    travis_retry curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
   else
-    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+    travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   fi
 
   # Use the more reliable S3 mirror of Hackage
@@ -134,10 +139,6 @@ before_install:
   echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
   echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
 
-  if [ "$CABALVER" != "1.16" ]
-  then
-    echo 'jobs: $ncpus' >> $HOME/.cabal/config
-  fi
 
 install:
 - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
@@ -147,9 +148,14 @@ install:
   case "$BUILD" in
     stack)
       # Add in extra-deps for older snapshots, as necessary
-      stack --no-terminal --install-ghc $ARGS test --bench --dry-run || ( \
-        stack --no-terminal $ARGS build cabal-install && \
-        stack --no-terminal $ARGS solver --update-config)
+      #
+      # This is disabled by default, as relying on the solver like this can
+      # make builds unreliable. Instead, if you have this situation, it's
+      # recommended that you maintain multiple stack-lts-X.yaml files.
+
+      #stack --no-terminal --install-ghc $ARGS test --bench --dry-run || ( \
+      #  stack --no-terminal $ARGS build cabal-install && \
+      #  stack --no-terminal $ARGS solver --update-config)
 
       # Build the dependencies
       stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
@@ -191,7 +197,11 @@ script:
         cd "$PKGVER"
         cabal configure --enable-tests --ghc-options -O0
         cabal build
-        cabal test
+        if [ "$CABALVER" = "1.16" ] || [ "$CABALVER" = "1.18" ]; then
+          cabal test
+        else
+          cabal test --show-details=streaming --log=/dev/stdout
+        fi
         cd $ORIGDIR
       done
       ;;

--- a/benchmarks/DBusBenchmarks.hs
+++ b/benchmarks/DBusBenchmarks.hs
@@ -40,13 +40,16 @@ benchUnmarshal :: Message msg => String -> msg -> Benchmark
 benchUnmarshal name msg = bench name (whnf unmarshal bytes) where
     Right bytes = marshal LittleEndian (serial 0) msg
 
+parseSig :: String -> Maybe Signature
+parseSig = parseSignature
+
 benchmarks :: [Benchmark]
 benchmarks =
     [  bgroup "Types"
         [ bgroup "Signature"
-            [ bench "parseSignature/small" (nf parseSignature "y")
-            , bench "parseSignature/medium" (nf parseSignature "yyyyuua(yv)")
-            , bench "parseSignature/large" (nf parseSignature "a{s(asiiiiasa(siiia{s(iiiiv)}))}")
+            [ bench "parseSignature/small" (nf parseSig "y")
+            , bench "parseSignature/medium" (nf parseSig "yyyyuua(yv)")
+            , bench "parseSignature/large" (nf parseSig "a{s(asiiiiasa(siiia{s(iiiiv)}))}")
             ]
         , bgroup "ObjectPath"
             [ bench "objectPath_/small" (nf objectPath_ "/")

--- a/dbus.cabal
+++ b/dbus.cabal
@@ -86,6 +86,7 @@ library
     , conduit
     , containers
     , deepseq
+    , exceptions
     , filepath
     , lens
     , network

--- a/dbus.cabal
+++ b/dbus.cabal
@@ -83,11 +83,11 @@ library
       base >=4 && <5
     , bytestring
     , cereal
+    , conduit
     , containers
     , deepseq
     , filepath
     , lens
-    , libxml-sax
     , network
     , parsec
     , random
@@ -98,6 +98,7 @@ library
     , transformers
     , unix
     , vector
+    , xml-conduit
     , xml-types
 
   exposed-modules:
@@ -128,7 +129,6 @@ test-suite dbus_tests
     , directory
     , extra
     , filepath
-    , libxml-sax
     , network
     , parsec
     , process
@@ -142,7 +142,6 @@ test-suite dbus_tests
     , transformers
     , unix
     , vector
-    , xml-types
 
   other-modules:
     DBusTests.Address

--- a/lib/DBus/Generation.hs
+++ b/lib/DBus/Generation.hs
@@ -9,6 +9,7 @@ import qualified DBus.Internal.Message as M
 import qualified DBus.Internal.Types as T
 import qualified DBus.Introspection as I
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.Char as Char
 import           Data.Coerce
 import           Data.Functor ((<$>))
@@ -537,7 +538,7 @@ generateSignal GenerationParams
 generateFromFilePath :: GenerationParams -> FilePath -> Q [Dec]
 generateFromFilePath generationParams filepath =
   let obj = unsafePerformIO $
-            head . maybeToList . I.parseXML "/" <$> readFile filepath
+            head . maybeToList . I.parseXML "/" <$> BL.readFile filepath
       interface = head $ I.objectInterfaces obj
       signals = generateSignalsFromInterface generationParams interface
       client = generateClient generationParams interface

--- a/lib/DBus/Introspection.hs
+++ b/lib/DBus/Introspection.hs
@@ -159,9 +159,7 @@ parseMethod = X.tag' "method" getName parseArgs
   where
     getName = do
         ifName <- X.requireAttr "name"
-        case T.parseMemberName (Text.unpack ifName) of
-            Just n -> pure n
-            Nothing -> throwM $ userError "invalid method name"
+        T.parseMemberName (Text.unpack ifName)
     parseArgs name = do
         args <- X.many $
             X.tag' "arg" getArg pure
@@ -180,9 +178,7 @@ parseSignal = X.tag' "signal" getName parseArgs
   where
     getName = do
         ifName <- X.requireAttr "name"
-        case T.parseMemberName (Text.unpack ifName) of
-            Just n -> pure n
-            Nothing -> throwM $ userError "invalid signal name"
+        T.parseMemberName (Text.unpack ifName)
     parseArgs name = do
         args <- X.many $
             X.tag' "arg" getArg pure
@@ -216,9 +212,7 @@ parseProperty = X.tag' "property" getProp $ \p -> do
 
 parseType :: MonadThrow m => Text.Text -> m T.Type
 parseType typeStr = do
-    typ <- case T.parseSignature (Text.unpack typeStr) of
-        Nothing -> throwM $ userError "invalid type sig"
-        Just t -> pure t
+    typ <- T.parseSignature (Text.unpack typeStr)
     case T.signatureTypes typ of
         [t] -> pure t
         _ -> throwM $ userError "invalid type sig"

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-11.2
+resolver: lts-12.18
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/tests/DBusTests/Client.hs
+++ b/tests/DBusTests/Client.hs
@@ -20,6 +20,7 @@ import Data.Word
 import Data.Int
 import Test.Tasty
 import Test.Tasty.HUnit
+import qualified Data.ByteString.Lazy.Char8 as BL8
 import qualified Data.Map as Map
 
 import DBus
@@ -598,7 +599,7 @@ test_ExportIntrospection =
             let body = methodReturnBody ret
             length body @?= 1
             let Just xml = fromVariant (head body)
-            return $ parseXML (objectPath_ "/") xml
+            return $ parseXML (objectPath_ "/") (BL8.pack xml)
       root <- introspect "/"
       root @?=
         Just

--- a/tests/DBusTests/Introspection.hs
+++ b/tests/DBusTests/Introspection.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 -- Copyright (C) 2010-2012 John Millikin <john@john-millikin.com>
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,6 +21,7 @@ import Test.QuickCheck
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck
+import qualified Data.ByteString.Lazy.Char8 as BL8
 
 import DBus
 import qualified DBus.Introspection as I
@@ -42,7 +44,7 @@ test_XmlPassthrough :: TestTree
 test_XmlPassthrough = testProperty "xml-passthrough" $ \obj -> let
     path = I.objectPath obj
     Just xml = I.formatXML obj
-    in I.parseXML path xml == Just obj
+    in I.parseXML path (BL8.pack xml) == Just obj
 
 buildEmptyObject :: String -> I.Object
 buildEmptyObject name = I.Object (objectPath_ name) [] []


### PR DESCRIPTION
This commit fixes issues #18 and, more importantly, #26. Either libxml bindings incorrectly work on 32-bit systems, or there is a bug in GHC. In any case, libxml-sax is long abandoned and needs to be replaced.