### PR TITLE
fix conduit bounds

### DIFF
--- a/dbus.cabal
+++ b/dbus.cabal
@@ -83,7 +83,7 @@ library
       base >=4 && <5
     , bytestring
     , cereal
-    , conduit
+    , conduit >= 1.3.0
     , containers
     , deepseq
     , exceptions


### PR DESCRIPTION
This fixes bounds for conduit, hopefully allowing builds with GHC 7.10.3 to succeed. 