### PR TITLE
Add safe typeOf' function

### DIFF
--- a/lib/DBus.hs
+++ b/lib/DBus.hs
@@ -75,6 +75,7 @@ module DBus
     , IsAtom
     , IsValue
     , typeOf
+    , typeOf'
 
     -- * Signatures
     , Signature
@@ -171,6 +172,7 @@ module DBus
 
 import           Control.Monad (replicateM)
 import qualified Data.ByteString.Char8 as Char8
+import           Data.Proxy (Proxy(..))
 import           Data.Word (Word16)
 import           System.Random (randomRIO)
 import           Text.Printf (printf)
@@ -178,13 +180,17 @@ import           Text.Printf (printf)
 import           DBus.Internal.Address
 import           DBus.Internal.Message
 import qualified DBus.Internal.Types
-import           DBus.Internal.Types hiding (typeOf)
+import           DBus.Internal.Types hiding (typeOf, typeOf')
 import           DBus.Internal.Wire
 
--- | Get the D-Bus type corresponding to the given Haskell value. The value
+-- | Deprecated. Get the D-Bus type corresponding to the given Haskell value. The value
 -- may be @undefined@.
 typeOf :: IsValue a => a -> Type
 typeOf = DBus.Internal.Types.typeOf
+
+-- | Get the D-Bus type corresponding to the given Haskell type 'a'.
+typeOf' :: IsValue a => Proxy a -> Type
+typeOf' = DBus.Internal.Types.typeOf'
 
 -- | Construct a new 'MethodCall' for the given object, interface, and method.
 --

--- a/lib/DBus/Client.hs
+++ b/lib/DBus/Client.hs
@@ -189,7 +189,7 @@ import Data.Maybe
 import Data.Monoid
 import Data.String
 import qualified Data.Traversable as T
-import Data.Typeable (Typeable)
+import Data.Typeable (Typeable, Proxy(..))
 import Data.Unique
 import Data.Word (Word32)
 import Prelude hiding (foldl, foldr, concat)
@@ -1108,7 +1108,7 @@ instance IsValue a => AutoMethod (IO a) where
 instance IsValue a => AutoMethod (DBusR a) where
     funTypes _ = ([], outTypes) where
       aType :: Type
-      aType = typeOf (undefined :: a)
+      aType = typeOf' (Proxy :: Proxy a)
       outTypes =
         case aType of
           TypeStructure ts -> ts
@@ -1124,7 +1124,7 @@ instance IsValue a => AutoMethod (IO (Either Reply a)) where
 instance IsValue a => AutoMethod (DBusR (Either Reply a)) where
     funTypes _ = ([], outTypes) where
       aType :: Type
-      aType = typeOf (undefined :: a)
+      aType = typeOf' (Proxy :: Proxy a)
       outTypes =
         case aType of
           TypeStructure ts -> ts
@@ -1176,7 +1176,7 @@ autoProperty
   => MemberName -> Maybe (IO v) -> Maybe (v -> IO ()) -> Property
 autoProperty name mgetter msetter =
   Property name propType (fmap toVariant <$> mgetter) (variantSetter <$> msetter)
-    where propType = typeOf (undefined :: v)
+    where propType = typeOf' (Proxy :: Proxy v)
           variantSetter setter =
             let newFun variant = maybe (return ()) setter (fromVariant variant)
             in newFun


### PR DESCRIPTION
Use of `undefined :: a` requires manually checking that value is not used. `Proxy a` shifts this to the compiler.