### PR TITLE
Patch for network 3.0.0.0

### DIFF
--- a/dbus.cabal
+++ b/dbus.cabal
@@ -1,5 +1,5 @@
 name: dbus
-version: 1.2.1
+version: 1.2.2
 license: Apache-2.0
 license-file: license.txt
 author: John Millikin <john@john-millikin.com>

--- a/lib/DBus/Transport.hs
+++ b/lib/DBus/Transport.hs
@@ -199,8 +199,8 @@ instance TransportListen SocketTransport where
 -- | Returns the processID, userID, and groupID of the socket's peer.
 --
 -- See 'getPeerCred'.
-socketTransportCredentials :: SocketTransport -> IO (CUInt, CUInt, CUInt)
-socketTransportCredentials (SocketTransport a s) = catchIOException a (getPeerCred s)
+socketTransportCredentials :: SocketTransport -> IO (Maybe CUInt, Maybe CUInt, Maybe CUInt)
+socketTransportCredentials (SocketTransport a s) = catchIOException a (getPeerCredential s)
 
 openUnix :: Address -> IO SocketTransport
 openUnix transportAddr = go where


### PR DESCRIPTION
This makes dbus not fail on the latest `network`