### PR TITLE
[xml] Ignore tags that aren't recognized as valid

### DIFF
--- a/lib/DBus/Introspection/Parse.hs
+++ b/lib/DBus/Introspection/Parse.hs
@@ -45,7 +45,7 @@ parseObject
 parseObject getPath = X.tag' "node" getPath parseContent
   where
     parseContent objPath = do
-        elems <- X.many $ X.choose
+        elems <- X.many' $ X.choose
             [ fmap SubNode <$> parseObject (getChildName objPath)
             , fmap InterfaceDefinition <$> parseInterface
             ]
@@ -63,7 +63,7 @@ parseInterface = X.tag' "interface" getName parseContent
         ifName <- X.requireAttr "name"
         pure $ interfaceName_ (T.unpack ifName)
     parseContent ifName = do
-        elems <- X.many $ do
+        elems <- X.many' $ do
             X.many_ $ X.ignoreTreeContent "annotation" X.ignoreAttrs
             X.choose
                 [ parseMethod
@@ -85,7 +85,7 @@ parseMethod = X.tag' "method" getName parseArgs
         ifName <- X.requireAttr "name"
         parseMemberName (T.unpack ifName)
     parseArgs name = do
-        args <- X.many $ do
+        args <- X.many' $ do
             X.many_ $ X.ignoreTreeContent "annotation" X.ignoreAttrs
             X.tag' "arg" getArg pure
         X.many_ $ X.ignoreTreeContent "annotation" X.ignoreAttrs
@@ -106,7 +106,7 @@ parseSignal = X.tag' "signal" getName parseArgs
         ifName <- X.requireAttr "name"
         parseMemberName (T.unpack ifName)
     parseArgs name = do
-        args <- X.many $ do
+        args <- X.many' $ do
             X.many_ $ X.ignoreTreeContent "annotation" X.ignoreAttrs
             X.tag' "arg" getArg pure
         X.many_ $ X.ignoreTreeContent "annotation" X.ignoreAttrs


### PR DESCRIPTION
This commit was made specifically to fix the case where the XML file contains imported namespaces, namely the official DBus Spec, which introduces special tags that haskell-dbus isn't normally aware of. Ignoring these tags prevents the parser from throwing an error at the first invalid tag.

@rblaze I'd like to note that this change breaks the XmlParseFailed test. It now parses only the nodes it can recognize and ignores the rest, but more importantly it does not fail. Is this acceptable behavior? If so, I'll update the test.