### PR TITLE
Fix Variant wrapping in setProperty; add property documentation and example

### DIFF
--- a/examples/property.hs
+++ b/examples/property.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- Copyright (C) 2025 Kevin Buhr <buhr@asaurus.net>
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+module Main (main) where
+
+import           System.Environment
+import           System.IO
+
+import           DBus
+import qualified DBus.Client as DBus
+
+wirelessPropertyMethod :: MethodCall
+wirelessPropertyMethod =
+    (methodCall "/org/freedesktop/NetworkManager" "org.freedesktop.NetworkManager" "WirelessEnabled")
+    { methodCallDestination = Just "org.freedesktop.NetworkManager" }
+
+getWirelessProperty :: IO ()
+getWirelessProperty = do
+    client <- DBus.connectSystem
+    res <- DBus.getPropertyValue client wirelessPropertyMethod
+    case res of
+        Left err -> print err
+        Right True  -> putStrLn "Wireless enabled"
+        Right False -> putStrLn "Wireless disabled"
+
+setWirelessProperty :: Bool -> IO ()
+setWirelessProperty b = do
+    client <- DBus.connectSystem
+    res <- DBus.setPropertyValue client wirelessPropertyMethod b
+    case res of
+        Just err -> print err
+        Nothing -> getWirelessProperty
+
+main :: IO ()
+main = do
+    args <- getArgs
+    case args of
+        ["enable"]  -> setWirelessProperty True
+        ["disable"] -> setWirelessProperty False
+        ["query"]   -> getWirelessProperty
+        _ -> do
+          cmd <- getProgName
+          hPutStrLn stderr $ "syntax: " ++ cmd ++ " [enable|disable|query]"

--- a/lib/DBus/Client.hs
+++ b/lib/DBus/Client.hs
@@ -897,7 +897,7 @@ unpackVariant MethodCall { methodCallSender = sender } variant =
                                  , methodErrorSender = sender
                                  } $ fromVariant variant
 
--- | Retrieve a property using the method call parameters that were provided.
+-- | Like `getPropertyValue`, but returns the value as a 'Variant'.
 --
 -- Throws a 'ClientError' if the property request couldn't be sent.
 getProperty :: Client -> MethodCall -> IO (Either MethodError Variant)
@@ -913,10 +913,19 @@ getProperty client
                                        ]
                     }
 
+-- | Get a property using the standard @\"org.freedesktop.DBus.Properties.Get\"@ method.
+-- The interface and property name are given by the 'methodCallInterface' and 'methodCallMember'
+-- fields of the supplied 'MethodCall'.  This function handles properties of fixed type.  For
+-- properties of varying types, use 'getProperty'.
+--
+-- Throws a 'ClientError' if the property request couldn't be sent.
 getPropertyValue :: IsValue a => Client -> MethodCall -> IO (Either MethodError a)
 getPropertyValue client msg =
   (>>= unpackVariant msg) <$> getProperty client msg
 
+-- | Like 'setPropertyValue', but expects the new value to be wrapped in a 'Variant'.
+--
+-- Throws a 'ClientError' if the property request couldn't be sent.
 setProperty :: Client -> MethodCall -> Variant -> IO (Either MethodError MethodReturn)
 setProperty client
             msg@MethodCall { methodCallInterface = interface
@@ -931,6 +940,11 @@ setProperty client
                     ]
                   }
 
+-- | Set a property using the standard @\"org.freedesktop.DBus.Properties.Set\"@ method.
+-- The interface and property name are given by the 'methodCallInterface' and 'methodCallMember'
+-- fields of the supplied 'MethodCall'.  See `setProperty` for a version that accepts a 'Variant'.
+--
+-- Throws a 'ClientError' if the property request couldn't be sent.
 setPropertyValue
   :: IsValue a
   => Client -> MethodCall -> a -> IO (Maybe MethodError)

--- a/lib/DBus/Client.hs
+++ b/lib/DBus/Client.hs
@@ -927,7 +927,7 @@ setProperty client
                   , methodCallBody =
                     [ toVariant (coerce (orDefaultInterface interface) :: String)
                     , toVariant (coerce member :: String)
-                    , value
+                    , toVariant value
                     ]
                   }
 


### PR DESCRIPTION
Add a variant wrapper in `setProperty` to fix the issue.  Also, add some documentation and an example.

Fixes #67